### PR TITLE
Change INF for echo sample to comply with new InfVerif requirements.

### DIFF
--- a/general/echo/kmdf/driver/DriverSync/echo_2.inx
+++ b/general/echo/kmdf/driver/DriverSync/echo_2.inx
@@ -7,8 +7,8 @@
 
 [Version]
 Signature   = "$WINDOWS NT$"
-Class       = Sample
-ClassGuid   = {78A1C341-4539-11d3-B88D-00C04FAD5171}
+Class       = Rust_Sample
+ClassGuid   = {BB0D3EC2-E59E-44CE-B711-A6BD51EB810E}
 Provider    = %ProviderString%
 PnpLockDown = 1
 


### PR DESCRIPTION
Using preview versions of the EWDK results in the build failing due to the sample using a reserved MSFT class in its INF:

```
[cargo-make][1] INFO - Execute Command: "infverif" "/v" "/w" "/msft" "C:\\Users\\natede\\source\\repos\\Windows-rust-driver-samples\\target/debug/echo_2.inf"
Running in Verbose
Running Windows Driver INF check
Running in MSFT driver mode

Validating echo_2.inf
ERROR(1284) in C:\Users\natede\source\repos\Windows-rust-driver-samples\target\debug\echo_2.inf, line 10: Class "Sample" is reserved for use by Microsoft.
ERROR(1285) in C:\Users\natede\source\repos\Windows-rust-driver-samples\target\debug\echo_2.inf, line 28: Cannot specify [ClassInstall32] section for Microsoft-defined class.
INF is NOT VALID
```

This PR updates the echo sample to use a custom "Rust_Sample" class.