### PR TITLE
feat: update samples to use 0.3.0 windows-drivers-rs crates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
+# Any flags here must be also added to env.RUSTFLAGS in build.yaml due to rustflag overriding rules: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,9 @@ on:
 name: Build
 
 env:
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: >-
+    -D warnings
+    -C target-feature=+crt-static
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,4 +81,4 @@ jobs:
           tool: cargo-make
 
       - name: Build and Package Sample Drivers
-        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}
+        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --env RUSTFLAGS="${{ env.RUSTFLAGS }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,4 +81,4 @@ jobs:
           tool: cargo-make
 
       - name: Build and Package Sample Drivers
-        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --env RUSTFLAGS="${{ env.RUSTFLAGS }}"
+        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}

--- a/.github/workflows/github-dependency-review.yaml
+++ b/.github/workflows/github-dependency-review.yaml
@@ -19,9 +19,13 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
-          # AND combinations are currently bugged and must be listed separately: https://github.com/actions/dependency-review-action/issues/263
-          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, Unicode-DFS-2016, (MIT OR Apache-2.0) AND Unicode-DFS-2016
-          # anstyle is licensed as (MIT OR Apache-2.0), but the Github api fails to detect it: https://github.com/rust-cli/anstyle/tree/main/crates/anstyle
+          allow-licenses: >-
+            MIT,
+            Apache-2.0,
+            BSD-3-Clause,
+            ISC,
+            Unicode-DFS-2016
+          # anstyle@1.0.4 is licensed as (MIT OR Apache-2.0), but the Github api fails to detect it: https://github.com/rust-cli/anstyle/tree/main/crates/anstyle
           allow-dependencies-licenses: 'pkg:cargo/anstyle@1.0.4'
           comment-summary-in-pr: on-failure
           # Explicit refs required for merge_group and push triggers:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "bindgen"
@@ -74,7 +74,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -96,9 +96,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -124,6 +124,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
+dependencies = [
+ "shlex",
 ]
 
 [[package]]
@@ -154,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -164,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
+checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
 dependencies = [
  "anstyle",
  "clap",
@@ -174,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -186,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -212,6 +221,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "echo-2"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "paste",
  "wdk",
  "wdk-alloc",
@@ -249,6 +259,7 @@ dependencies = [
 name = "fail_driver_pool_leak"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "wdk",
  "wdk-alloc",
  "wdk-build",
@@ -264,9 +275,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
@@ -287,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,9 +314,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
@@ -390,9 +410,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -412,18 +432,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -493,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -566,9 +586,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -578,9 +598,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -589,18 +609,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -624,7 +644,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -706,47 +738,58 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e255fa09cb7395c5f9b8c72831347c9b77aa51fc66c3f44eb5d097a44122e9f"
+checksum = "c80cc00b5c587d3a43f489350a797a258eefca5ab0bb5d0d5b56d4ce09ab42f2"
 dependencies = [
+ "tracing",
+ "tracing-subscriber",
  "wdk-build",
  "wdk-sys",
 ]
 
 [[package]]
 name = "wdk-alloc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c3180aa54fa2e30ecfd52a9e40210e634c09f760658cf8793ef0bf2ee7d917"
+checksum = "5dd1c139c6b9c05475bc7e8b356d4fbc252954d685691d70cfaec8b42c41b72d"
 dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wdk-build",
  "wdk-sys",
 ]
 
 [[package]]
 name = "wdk-build"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78da0616ae3b04f9488d250e8b087b7b332e7f1f18b4c7bcedebf7aea6231594"
+checksum = "4b276786d848e5ab00e021968e89cfdc591938b69741a3733e7e3d91b23f547f"
 dependencies = [
+ "anyhow",
  "bindgen",
+ "camino",
  "cargo_metadata",
+ "cfg-if",
  "clap",
  "clap-cargo",
+ "lazy_static",
+ "paste",
  "rustversion",
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
  "windows",
 ]
 
 [[package]]
 name = "wdk-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a27743e45f2bacdc8a778482a52ea2fda527bdac95bad5086cee080441b2da"
+checksum = "56f069b2e89e5a3327e84bc2f672f7f35d94059da590666d7d605f33f2ae2fa3"
 dependencies = [
- "cfg-if",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -754,21 +797,25 @@ dependencies = [
 
 [[package]]
 name = "wdk-panic"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56558972c0d7069aa3b2b409752e65db7ba3fd24fcffc3887d19b6e48585e4"
+checksum = "6ba15dc2294f5c87df4b30218d93fb459ac8484a45683d4ad06fc0243e58736c"
 
 [[package]]
 name = "wdk-sys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c6fbc666a0535164ebbb16cff321ee2cac38636aa6b9f1712148388f401087"
+checksum = "10f974829a3b0b362723d55f0d05d8f1715bb7a88297558c4127f69d85bbff7e"
 dependencies = [
  "anyhow",
  "bindgen",
+ "cargo_metadata",
+ "cc",
  "lazy_static",
  "rustversion",
+ "serde_json",
  "thiserror",
+ "tracing",
  "tracing-subscriber",
  "wdk-build",
  "wdk-macros",
@@ -810,21 +857,66 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -842,7 +934,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -862,17 +954,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -883,9 +976,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -895,9 +988,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -907,9 +1000,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -919,9 +1018,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -931,9 +1030,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -943,9 +1042,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -955,6 +1054,6 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ driver-type = "KMDF"
 kmdf-version-major = 1
 target-kmdf-version-minor = 33
 
-
 [profile.dev]
 panic = "abort"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ panic = "abort"
 lto = true
 
 [workspace.dependencies]
-wdk = "0.2.0"
-wdk-alloc = "0.2.0"
-wdk-build = "0.2.0"
-wdk-panic = "0.2.0"
-wdk-sys = "0.2.0"
+wdk = "0.3.0"
+wdk-alloc = "0.3.0"
+wdk-build = "0.3.0"
+wdk-panic = "0.3.0"
+wdk-sys = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,22 @@ publish = false
 repository = "https://github.com/microsoft/windows-rust-driver-samples"
 license = "MIT OR Apache-2.0"
 
+[workspace.metadata.wdk.driver-model]
+driver-type = "KMDF"
+kmdf-version-major = 1
+target-kmdf-version-minor = 33
+
+
 [profile.dev]
 panic = "abort"
-lto = true
 
 [profile.release]
 panic = "abort"
 lto = true
 
 [workspace.dependencies]
+anyhow = "1.0.89"
+paste = "1.0.14"
 wdk = "0.3.0"
 wdk-alloc = "0.3.0"
 wdk-build = "0.3.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,19 +1,19 @@
-extend = "target/rust-driver-makefile.toml"
+extend = [ { path =  "target/rust-driver-makefile.toml" }, { path = "target/rust-driver-sample-makefile.toml" } ]
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
-WDK_BUILD_ADDITIONAL_INFVERIF_FLAGS = "/msft"
 
 [config]
 load_script = '''
 #!@rust
 //! ```cargo
 //! [dependencies]
-//! wdk-build = "0.2.0"
+//! wdk-build = "0.3.0"
 //! ```
 #![allow(unused_doc_comments)]
 
-wdk_build::cargo_make::load_rust_driver_makefile()?
+wdk_build::cargo_make::load_rust_driver_makefile()?;
+wdk_build::cargo_make::load_rust_driver_sample_makefile()?
 '''
 
 [tasks.default]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,7 @@
-extend = [ { path =  "target/rust-driver-makefile.toml" }, { path = "target/rust-driver-sample-makefile.toml" } ]
+extend = [
+  { path = "target/rust-driver-makefile.toml" },
+  { path = "target/rust-driver-sample-makefile.toml" },
+]
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
@@ -15,8 +18,3 @@ load_script = '''
 wdk_build::cargo_make::load_rust_driver_makefile()?;
 wdk_build::cargo_make::load_rust_driver_sample_makefile()?
 '''
-
-[tasks.default]
-# Since this worspace contains both driver and non-driver crates, we need to explicitly specify `build` so that non-driver crates are still compiled
-clear = true
-dependencies = ["build", "package-driver-flow"]

--- a/general/echo/kmdf/driver/DriverSync/Cargo.toml
+++ b/general/echo/kmdf/driver/DriverSync/Cargo.toml
@@ -2,7 +2,6 @@
 name = "echo-2"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-rust-version = "1.72.1"
 edition.workspace = true
 publish.workspace = true
 
@@ -10,15 +9,18 @@ publish.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+# Tests from root driver crates must be excluded since there's no way to prevent linker args from being passed to their unit tests: https://github.com/rust-lang/cargo/issues/12663
+test = false
 
 [dependencies]
+paste.workspace = true
 wdk.workspace = true
 wdk-alloc.workspace = true
 wdk-panic.workspace = true
 wdk-sys.workspace = true
-paste = "1.0.14"
 
 [build-dependencies]
+anyhow.workspace = true
 wdk-build.workspace = true
 
 [features]

--- a/general/echo/kmdf/driver/DriverSync/Cargo.toml
+++ b/general/echo/kmdf/driver/DriverSync/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "echo-2"
 version = "0.1.0"
-license = "MIT OR Apache-2.0"
 edition.workspace = true
+license.workspace = true
 publish.workspace = true
 
 [package.metadata.wdk]
+# Using workspace wdk config
 
 [lib]
 crate-type = ["cdylib"]

--- a/general/echo/kmdf/driver/DriverSync/build.rs
+++ b/general/echo/kmdf/driver/DriverSync/build.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
-fn main() -> Result<(), wdk_build::ConfigError> {
-    wdk_build::Config::from_env_auto()?.configure_binary_build();
-    Ok(())
+fn main() -> anyhow::Result<()> {
+    Ok(wdk_build::configure_wdk_binary_build()?)
 }

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -59,13 +59,13 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
 
     // Register the PnP and power callbacks. Power policy related callbacks will be
     // registered later in SotwareInit.
-    let [()] = [unsafe {
+    unsafe {
         call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetPnpPowerEventCallbacks,
             device_init,
             &mut pnp_power_callbacks
         );
-    }];
+    };
 
     let mut attributes = WDF_OBJECT_ATTRIBUTES {
         Size: core::mem::size_of::<WDF_OBJECT_ATTRIBUTES>() as ULONG,
@@ -75,13 +75,13 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
         ..WDF_OBJECT_ATTRIBUTES::default()
     };
 
-    let [()] = [unsafe {
+    unsafe {
         call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetRequestAttributes,
             device_init,
             &mut attributes
         );
-    }];
+    };
 
     let mut attributes = WDF_OBJECT_ATTRIBUTES {
         Size: core::mem::size_of::<WDF_OBJECT_ATTRIBUTES>() as ULONG,
@@ -161,7 +161,7 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
 
     // Restart the queue and the periodic timer. We stopped them before going
     // into low power state.
-    let [()] = [unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) }];
+    unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) };
 
     let due_time: i64 = -(100) * (10000);
 
@@ -203,10 +203,7 @@ unsafe extern "C" fn echo_evt_device_self_managed_io_suspend(device: WDFDEVICE) 
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };
 
     unsafe {
-        let [()] = [call_unsafe_wdf_function_binding!(
-            WdfIoQueueStopSynchronously,
-            queue
-        )];
+        call_unsafe_wdf_function_binding!(WdfIoQueueStopSynchronously, queue);
         // Stop the watchdog timer and wait for DPC to run to completion if it's already
         // fired.
         let _ = (*queue_context).timer.stop(true);

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -3,7 +3,7 @@
 
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
-    macros,
+    call_unsafe_wdf_function_binding,
     APC_LEVEL,
     NTSTATUS,
     STATUS_SUCCESS,
@@ -60,7 +60,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
     // Register the PnP and power callbacks. Power policy related callbacks will be
     // registered later in SotwareInit.
     let [()] = [unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetPnpPowerEventCallbacks,
             device_init,
             &mut pnp_power_callbacks
@@ -76,7 +76,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
     };
 
     let [()] = [unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetRequestAttributes,
             device_init,
             &mut attributes
@@ -93,7 +93,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
 
     let mut device = WDF_NO_HANDLE as WDFDEVICE;
     let mut nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDeviceCreate,
             (core::ptr::addr_of_mut!(device_init)) as *mut *mut WDFDEVICE_INIT,
             &mut attributes,
@@ -114,7 +114,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
         // Create a device interface so that application can find and talk
         // to us.
         nt_status = unsafe {
-            macros::call_unsafe_wdf_function_binding!(
+            call_unsafe_wdf_function_binding!(
                 WdfDeviceCreateDeviceInterface,
                 device,
                 &GUID_DEVINTERFACE_ECHO,
@@ -154,14 +154,14 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
     println!("--> EchoEvtDeviceSelfManagedIoInit");
 
     unsafe {
-        queue = macros::call_unsafe_wdf_function_binding!(WdfDeviceGetDefaultQueue, device);
+        queue = call_unsafe_wdf_function_binding!(WdfDeviceGetDefaultQueue, device);
     };
 
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };
 
     // Restart the queue and the periodic timer. We stopped them before going
     // into low power state.
-    let [()] = [unsafe { macros::call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) }];
+    let [()] = [unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) }];
 
     let due_time: i64 = -(100) * (10000);
 
@@ -199,12 +199,11 @@ unsafe extern "C" fn echo_evt_device_self_managed_io_suspend(device: WDFDEVICE) 
     // with outstanding I/O. In this sample we will use the 1st approach
     // because it's pretty easy to do. We will restart the queue when the
     // device is restarted.
-    let queue =
-        unsafe { macros::call_unsafe_wdf_function_binding!(WdfDeviceGetDefaultQueue, device) };
+    let queue = unsafe { call_unsafe_wdf_function_binding!(WdfDeviceGetDefaultQueue, device) };
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };
 
     unsafe {
-        let [()] = [macros::call_unsafe_wdf_function_binding!(
+        let [()] = [call_unsafe_wdf_function_binding!(
             WdfIoQueueStopSynchronously,
             queue
         )];

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -3,24 +3,7 @@
 
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
-    macros,
-    ntddk::KeGetCurrentIrql,
-    APC_LEVEL,
-    DRIVER_OBJECT,
-    NTSTATUS,
-    PCUNICODE_STRING,
-    PDRIVER_OBJECT,
-    PWDFDEVICE_INIT,
-    STATUS_SUCCESS,
-    ULONG,
-    UNICODE_STRING,
-    WDFDRIVER,
-    WDFOBJECT,
-    WDFSTRING,
-    WDF_DRIVER_CONFIG,
-    WDF_DRIVER_VERSION_AVAILABLE_PARAMS,
-    WDF_NO_HANDLE,
-    WDF_NO_OBJECT_ATTRIBUTES,
+    call_unsafe_wdf_function_binding, ntddk::KeGetCurrentIrql, APC_LEVEL, DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING, PDRIVER_OBJECT, PWDFDEVICE_INIT, STATUS_SUCCESS, ULONG, UNICODE_STRING, WDFDRIVER, WDFOBJECT, WDFSTRING, WDF_DRIVER_CONFIG, WDF_DRIVER_VERSION_AVAILABLE_PARAMS, WDF_NO_HANDLE, WDF_NO_OBJECT_ATTRIBUTES
 };
 
 use crate::device;
@@ -62,7 +45,7 @@ extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE.cast::<WDFDRIVER>();
 
     let nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDriverCreate,
             driver as PDRIVER_OBJECT,
             registry_path,
@@ -127,7 +110,7 @@ fn echo_print_driver_version() -> NTSTATUS {
     let mut string: WDFSTRING = core::ptr::null_mut();
     let mut us: UNICODE_STRING = UNICODE_STRING::default();
     let mut nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfStringCreate,
             core::ptr::null_mut(),
             WDF_NO_OBJECT_ATTRIBUTES,
@@ -139,10 +122,9 @@ fn echo_print_driver_version() -> NTSTATUS {
         return nt_status;
     }
 
-    // driver = unsafe{macros::call_unsafe_wdf_function_binding!(WdfGetDriver)};
     let driver = unsafe { (*wdk_sys::WdfDriverGlobals).Driver };
     nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(WdfDriverRetrieveVersionString, driver, string)
+        call_unsafe_wdf_function_binding!(WdfDriverRetrieveVersionString, driver, string)
     };
     if !nt_success(nt_status) {
         // No need to worry about delete the string object because
@@ -155,7 +137,7 @@ fn echo_print_driver_version() -> NTSTATUS {
     }
 
     let [()] = [unsafe {
-        macros::call_unsafe_wdf_function_binding!(WdfStringGetUnicodeString, string, &mut us);
+        call_unsafe_wdf_function_binding!(WdfStringGetUnicodeString, string, &mut us);
     }];
     let driver_version = String::from_utf16_lossy(unsafe {
         slice::from_raw_parts(
@@ -166,7 +148,7 @@ fn echo_print_driver_version() -> NTSTATUS {
     println!("Echo Sample {driver_version}");
 
     let [()] = [unsafe {
-        macros::call_unsafe_wdf_function_binding!(WdfObjectDelete, string as WDFOBJECT);
+        call_unsafe_wdf_function_binding!(WdfObjectDelete, string as WDFOBJECT);
     }];
     // string = core::ptr::null_mut();
 
@@ -178,9 +160,8 @@ fn echo_print_driver_version() -> NTSTATUS {
         MinorVersion: 0,
     };
 
-    if unsafe {
-        macros::call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &mut ver)
-    } > 0
+    if unsafe { call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &mut ver) }
+        > 0
     {
         println!("Yes, framework version is 1.0");
     } else {

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -3,7 +3,24 @@
 
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
-    call_unsafe_wdf_function_binding, ntddk::KeGetCurrentIrql, APC_LEVEL, DRIVER_OBJECT, NTSTATUS, PCUNICODE_STRING, PDRIVER_OBJECT, PWDFDEVICE_INIT, STATUS_SUCCESS, ULONG, UNICODE_STRING, WDFDRIVER, WDFOBJECT, WDFSTRING, WDF_DRIVER_CONFIG, WDF_DRIVER_VERSION_AVAILABLE_PARAMS, WDF_NO_HANDLE, WDF_NO_OBJECT_ATTRIBUTES
+    call_unsafe_wdf_function_binding,
+    ntddk::KeGetCurrentIrql,
+    APC_LEVEL,
+    DRIVER_OBJECT,
+    NTSTATUS,
+    PCUNICODE_STRING,
+    PDRIVER_OBJECT,
+    PWDFDEVICE_INIT,
+    STATUS_SUCCESS,
+    ULONG,
+    UNICODE_STRING,
+    WDFDRIVER,
+    WDFOBJECT,
+    WDFSTRING,
+    WDF_DRIVER_CONFIG,
+    WDF_DRIVER_VERSION_AVAILABLE_PARAMS,
+    WDF_NO_HANDLE,
+    WDF_NO_OBJECT_ATTRIBUTES,
 };
 
 use crate::device;
@@ -136,9 +153,9 @@ fn echo_print_driver_version() -> NTSTATUS {
         return nt_status;
     }
 
-    let [()] = [unsafe {
+    unsafe {
         call_unsafe_wdf_function_binding!(WdfStringGetUnicodeString, string, &mut us);
-    }];
+    };
     let driver_version = String::from_utf16_lossy(unsafe {
         slice::from_raw_parts(
             us.Buffer,
@@ -147,9 +164,9 @@ fn echo_print_driver_version() -> NTSTATUS {
     });
     println!("Echo Sample {driver_version}");
 
-    let [()] = [unsafe {
+    unsafe {
         call_unsafe_wdf_function_binding!(WdfObjectDelete, string as WDFOBJECT);
-    }];
+    };
     // string = core::ptr::null_mut();
 
     // 2) Find out to which version of framework this driver is bound to.

--- a/general/echo/kmdf/driver/DriverSync/src/lib.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/lib.rs
@@ -29,7 +29,6 @@
 //!    strategy for managing multiple requests outstanding.
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(hint_must_use))]
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
@@ -45,9 +44,9 @@ extern crate wdk_panic;
 
 use wdk::wdf;
 #[cfg(not(test))]
-use wdk_alloc::WDKAllocator;
+use wdk_alloc::WdkAllocator;
 use wdk_sys::{
-    macros,
+    call_unsafe_wdf_function_binding,
     ntddk::KeGetCurrentIrql,
     GUID,
     NTSTATUS,
@@ -64,7 +63,7 @@ use wdf_object_context::{wdf_declare_context_type, wdf_declare_context_type_with
 
 #[cfg(not(test))]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: WDKAllocator = WDKAllocator;
+static GLOBAL_ALLOCATOR: WdkAllocator = WdkAllocator;
 
 // {CDC35B6E-0BE4-4936-BF5F-5537380A7C1A}
 const GUID_DEVINTERFACE_ECHO: GUID = GUID {

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -5,7 +5,7 @@ use core::sync::atomic::Ordering;
 
 use wdk::{nt_success, paged_code, println, wdf};
 use wdk_sys::{
-    macros,
+    call_unsafe_wdf_function_binding,
     ntddk::{ExAllocatePool2, ExFreePool, KeGetCurrentIrql},
     APC_LEVEL,
     NTSTATUS,
@@ -158,7 +158,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
 
     // Create queue.
     let nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfIoQueueCreate,
             device,
             &mut queue_config,
@@ -299,7 +299,7 @@ fn echo_increment_request_cancel_ownership_count(request_context: *mut RequestCo
 ///
 /// * `VOID`
 extern "C" fn echo_evt_request_cancel(request: WDFREQUEST) {
-    let queue = unsafe { macros::call_unsafe_wdf_function_binding!(WdfRequestGetIoQueue, request) };
+    let queue = unsafe { call_unsafe_wdf_function_binding!(WdfRequestGetIoQueue, request) };
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };
     let request_context = unsafe { request_get_context(request as WDFOBJECT) };
 
@@ -326,7 +326,7 @@ extern "C" fn echo_evt_request_cancel(request: WDFREQUEST) {
     // Complete the request outside of holding any locks
     if complete_request {
         let [()] = [unsafe {
-            macros::call_unsafe_wdf_function_binding!(
+            call_unsafe_wdf_function_binding!(
                 WdfRequestCompleteWithInformation,
                 request,
                 STATUS_CANCELLED,
@@ -371,7 +371,7 @@ fn echo_set_current_request(request: WDFREQUEST, queue: WDFQUEUE) {
     // WdfRequestMarkCancelableEx here to prevent to deadlock with ourselves
     // (cancel routine tries to acquire the queue object lock).
     unsafe {
-        status = macros::call_unsafe_wdf_function_binding!(
+        status = call_unsafe_wdf_function_binding!(
             WdfRequestMarkCancelableEx,
             request,
             Some(echo_evt_request_cancel)
@@ -386,7 +386,7 @@ fn echo_set_current_request(request: WDFREQUEST, queue: WDFQUEUE) {
     unsafe {
         // Complete the request with an error when unable to mark it cancelable.
         if !nt_success(status) {
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestCompleteWithInformation,
                 request,
                 status,
@@ -427,7 +427,7 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
     // No data to read
     unsafe {
         if (*queue_context).buffer.is_null() {
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestCompleteWithInformation,
                 request,
                 STATUS_SUCCESS,
@@ -446,15 +446,12 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 
     // Get the request memory
     unsafe {
-        nt_status = macros::call_unsafe_wdf_function_binding!(
-            WdfRequestRetrieveOutputMemory,
-            request,
-            &mut memory
-        );
+        nt_status =
+            call_unsafe_wdf_function_binding!(WdfRequestRetrieveOutputMemory, request, &mut memory);
 
         if !nt_success(nt_status) {
             println!("echo_evt_io_read Could not get request memory buffer {nt_status:#010X}");
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestCompleteWithInformation,
                 request,
                 nt_status,
@@ -466,7 +463,7 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 
     // Copy the memory out
     unsafe {
-        nt_status = macros::call_unsafe_wdf_function_binding!(
+        nt_status = call_unsafe_wdf_function_binding!(
             WdfMemoryCopyFromBuffer,
             memory,
             0,
@@ -476,7 +473,7 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 
         if !nt_success(nt_status) {
             println!("echo_evt_io_read: WdfMemoryCopyFromBuffer failed {nt_status:#010X}");
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestComplete,
                 request,
                 nt_status
@@ -487,7 +484,7 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 
     // Set transfer information
     let [()] = unsafe {
-        [macros::call_unsafe_wdf_function_binding!(
+        [call_unsafe_wdf_function_binding!(
             WdfRequestSetInformation,
             request,
             length as u64
@@ -536,7 +533,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
                 "echo_evt_io_write Buffer Length to big {:?}, Max is {:?}",
                 length, MAX_WRITE_LENGTH
             );
-            macros::call_unsafe_wdf_function_binding!(
+            call_unsafe_wdf_function_binding!(
                 WdfRequestCompleteWithInformation,
                 request,
                 STATUS_BUFFER_OVERFLOW,
@@ -547,14 +544,11 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
 
     // Get the memory buffer
     unsafe {
-        status = macros::call_unsafe_wdf_function_binding!(
-            WdfRequestRetrieveInputMemory,
-            request,
-            &mut memory
-        );
+        status =
+            call_unsafe_wdf_function_binding!(WdfRequestRetrieveInputMemory, request, &mut memory);
         if !nt_success(status) {
             println!("echo_evt_io_write Could not get request memory buffer {status:#010X}");
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestComplete,
                 request,
                 status
@@ -579,7 +573,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
                 "echo_evt_io_write Could not allocate {:?} byte buffer",
                 length
             );
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestComplete,
                 request,
                 STATUS_INSUFFICIENT_RESOURCES
@@ -590,7 +584,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
 
     // Copy the memory in
     unsafe {
-        status = macros::call_unsafe_wdf_function_binding!(
+        status = call_unsafe_wdf_function_binding!(
             WdfMemoryCopyToBuffer,
             memory,
             0,
@@ -603,7 +597,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
             ExFreePool((*queue_context).buffer);
             (*queue_context).buffer = core::ptr::null_mut();
             (*queue_context).length = 0;
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestComplete,
                 request,
                 status
@@ -616,7 +610,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
 
     // Set transfer information
     unsafe {
-        let [()] = [macros::call_unsafe_wdf_function_binding!(
+        let [()] = [call_unsafe_wdf_function_binding!(
             WdfRequestSetInformation,
             request,
             length as u64
@@ -653,8 +647,7 @@ unsafe extern "C" fn echo_evt_timer_func(timer: WDFTIMER) {
     let request: WDFREQUEST;
     let mut request_context: *mut RequestContext = core::ptr::null_mut();
     unsafe {
-        queue =
-            macros::call_unsafe_wdf_function_binding!(WdfTimerGetParentObject, timer,) as WDFQUEUE;
+        queue = call_unsafe_wdf_function_binding!(WdfTimerGetParentObject, timer,) as WDFQUEUE;
     }
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };
 
@@ -687,7 +680,7 @@ unsafe extern "C" fn echo_evt_timer_func(timer: WDFTIMER) {
     // The request handle and requestContext are valid until we release
     // the cancel ownership count we already acquired.
     unsafe {
-        status = macros::call_unsafe_wdf_function_binding!(WdfRequestUnmarkCancelable, request,);
+        status = call_unsafe_wdf_function_binding!(WdfRequestUnmarkCancelable, request,);
         if status != STATUS_CANCELLED {
             println!(
                 "CustomTimerDPC successfully cleared cancel routine on request {:?}, status {:?}",
@@ -739,7 +732,7 @@ unsafe extern "C" fn echo_evt_timer_func(timer: WDFTIMER) {
         unsafe { (*queue_context).spin_lock.release() };
 
         unsafe {
-            let [()] = [macros::call_unsafe_wdf_function_binding!(
+            let [()] = [call_unsafe_wdf_function_binding!(
                 WdfRequestComplete,
                 request,
                 status

--- a/general/echo/kmdf/driver/DriverSync/src/wdf_object_context.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/wdf_object_context.rs
@@ -48,7 +48,7 @@ macro_rules! wdf_declare_context_type_with_name {
 
             pub unsafe fn $casting_function(handle: WDFOBJECT) -> [<WDFPointerType$context_type>] {
                 unsafe {
-                    macros::call_unsafe_wdf_function_binding!(
+                    call_unsafe_wdf_function_binding!(
                         WdfObjectGetTypedContextWorker,
                         handle,
                         crate::wdf_object_context::wdf_get_context_type_info!($context_type),

--- a/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
+++ b/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [package.metadata.wdk]
+# Using workspace wdk config
 
 [lib]
 crate-type = ["cdylib"]

--- a/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
+++ b/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+# Tests from root driver crates must be excluded since there's no way to prevent linker args from being passed to their unit tests: https://github.com/rust-lang/cargo/issues/12663
+test = false
 
 [dependencies]
 wdk.workspace = true
@@ -18,6 +20,7 @@ wdk-panic.workspace = true
 wdk-sys.workspace = true
 
 [build-dependencies]
+anyhow.workspace = true
 wdk-build.workspace = true
 
 [features]

--- a/tools/dv/kmdf/fail_driver_pool_leak/build.rs
+++ b/tools/dv/kmdf/fail_driver_pool_leak/build.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // License: MIT OR Apache-2.0
 
-fn main() -> Result<(), wdk_build::ConfigError> {
-    wdk_build::Config::from_env_auto()?.configure_binary_build();
-    Ok(())
+fn main() -> anyhow::Result<()> {
+    Ok(wdk_build::configure_wdk_binary_build()?)
 }

--- a/tools/dv/kmdf/fail_driver_pool_leak/src/driver.rs
+++ b/tools/dv/kmdf/fail_driver_pool_leak/src/driver.rs
@@ -3,7 +3,7 @@
 
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
-    macros,
+    call_unsafe_wdf_function_binding,
     ntddk::{ExAllocatePool2, KeGetCurrentIrql},
     APC_LEVEL,
     DRIVER_OBJECT,
@@ -79,7 +79,7 @@ extern "system" fn driver_entry(
     let driver_handle_output = WDF_NO_HANDLE.cast::<WDFDRIVER>();
 
     let nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDriverCreate,
             driver as PDRIVER_OBJECT,
             registry_path,
@@ -131,7 +131,7 @@ extern "C" fn evt_driver_device_add(
 
     let mut device = WDF_NO_HANDLE as WDFDEVICE;
     let mut nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDeviceCreate,
             &mut device_init,
             &mut attributes,
@@ -153,7 +153,7 @@ extern "C" fn evt_driver_device_add(
     }
 
     nt_status = unsafe {
-        macros::call_unsafe_wdf_function_binding!(
+        call_unsafe_wdf_function_binding!(
             WdfDeviceCreateDeviceInterface,
             device,
             &GUID_DEVINTERFACE,

--- a/tools/dv/kmdf/fail_driver_pool_leak/src/lib.rs
+++ b/tools/dv/kmdf/fail_driver_pool_leak/src/lib.rs
@@ -17,7 +17,6 @@
 //! session, the bug can be analyzed further.
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(hint_must_use))]
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
@@ -29,11 +28,11 @@
 extern crate wdk_panic;
 
 #[cfg(not(test))]
-use wdk_alloc::WDKAllocator;
+use wdk_alloc::WdkAllocator;
 
 #[cfg(not(test))]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: WDKAllocator = WDKAllocator;
+static GLOBAL_ALLOCATOR: WdkAllocator = WdkAllocator;
 
 use wdk_sys::{GUID, PVOID};
 


### PR DESCRIPTION
Update this repo to use an upcoming 0.3.0 release of [windows-drivers-rs](https://github.com/microsoft/windows-drivers-rs/), including the changes from https://github.com/microsoft/windows-drivers-rs/pull/143.

This of course does not build today, but was validated with local changes.