### PR TITLE
ci: pin LLVM version in pipelines

### DIFF
--- a/.github/actions/winget-install/action.yml
+++ b/.github/actions/winget-install/action.yml
@@ -2,7 +2,7 @@ name: "Install Winget"
 description: "Install winget on windows runners since its not installed by default: https://github.com/actions/runner-images/issues/6472"
 inputs:
   GITHUB_TOKEN:
-    description: 'GitHub token to execute authenticated Github API requests (for higher rate limit)'
+    description: "GitHub token to execute authenticated Github API requests (for higher rate limit)"
     required: true
 runs:
   using: "composite"
@@ -45,3 +45,7 @@ runs:
           Start-Sleep -Seconds 1
         }
         Write-Output "Winget Version: $(winget --version)"
+
+    - name: Install winget Powershell Module
+      shell: pwsh
+      run: Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,9 @@ jobs:
         wdk:
           - Microsoft.WindowsWDK.10.0.22621 # NI WDK
 
+        llvm:
+          - 17.0.6
+
         rust_toolchain:
           - stable
           - beta
@@ -41,10 +44,24 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: |
+          if ((Get-WinGetPackage -Id LLVM -Source winget -MatchOption Equals).InstalledVersion -eq '${{ matrix.llvm }}') {
+            Write-Host "LLVM ${{ matrix.llvm }} is already installed."
+          } else {
+            Write-Host "Installing LLVM ${{ matrix.llvm }}..."
+            Install-WinGetPackage -Id LLVM.LLVM -Version ${{ matrix.llvm }} -Source winget -MatchOption Equals -Mode Silent -Force
+          }
+          clang --version
+
       - name: Install WDK (${{ matrix.wdk }})
         run: |
-          if (!(winget list --exact --source winget --id ${{ matrix.wdk }})[-1].contains("${{ matrix.wdk }}")) {
-            winget install --disable-interactivity --source winget --exact --id ${{ matrix.wdk }}
+          if ((Get-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals).Id -eq '${{ matrix.wdk }}') {
+            Write-Host "${{ matrix.wdk }} is already installed. Attempting to update..."
+            Update-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+          } else {
+            Write-Host "Installing ${{ matrix.wdk }}..."
+            Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
           }
 
       - name: Install Rust Toolchain (${{ matrix.rust_toolchain }})

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -17,14 +17,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain (Nightly)
-        # Need to temporarily pin nightly used for fmt because of upstream bug: https://github.com/rust-lang/rustfmt/issues/6082, https://github.com/rust-lang/rustfmt/issues/6099
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with: 
-          toolchain: nightly-2024-02-17
           components: rustfmt
 
       - name: Run Cargo Format
-        run: cargo +nightly-2024-02-17 fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
   taplo-fmt:
     name: .toml Formatting Check

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,9 @@ on:
 
 name: Docs
 
+env:
+  RUSTDOCFLAGS: -D warnings
+
 jobs:
   docs:
     name: Docs
@@ -15,6 +18,9 @@ jobs:
       matrix:
         wdk:
           - Microsoft.WindowsWDK.10.0.22621 # NI WDK
+
+        llvm:
+          - 17.0.6
 
         rust_toolchain:
           - stable
@@ -38,10 +44,24 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: |
+          if ((Get-WinGetPackage -Id LLVM -Source winget -MatchOption Equals).InstalledVersion -eq '${{ matrix.llvm }}') {
+            Write-Host "LLVM ${{ matrix.llvm }} is already installed."
+          } else {
+            Write-Host "Installing LLVM ${{ matrix.llvm }}..."
+            Install-WinGetPackage -Id LLVM.LLVM -Version ${{ matrix.llvm }} -Source winget -MatchOption Equals -Mode Silent -Force
+          }
+          clang --version
+
       - name: Install WDK (${{ matrix.wdk }})
         run: |
-          if (!(winget list --exact --source winget --id ${{ matrix.wdk }})[-1].contains("${{ matrix.wdk }}")) {
-            winget install --disable-interactivity --source winget --exact --id ${{ matrix.wdk }}
+          if ((Get-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals).Id -eq '${{ matrix.wdk }}') {
+            Write-Host "${{ matrix.wdk }} is already installed. Attempting to update..."
+            Update-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+          } else {
+            Write-Host "Installing ${{ matrix.wdk }}..."
+            Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
           }
 
       - name: Install Rust Toolchain (${{ matrix.rust_toolchain }})

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,9 @@ jobs:
         wdk:
           - Microsoft.WindowsWDK.10.0.22621 # NI WDK
 
+        llvm:
+          - 17.0.6
+
         rust_toolchain:
           - stable
           - beta
@@ -40,10 +43,24 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: |
+          if ((Get-WinGetPackage -Id LLVM -Source winget -MatchOption Equals).InstalledVersion -eq '${{ matrix.llvm }}') {
+            Write-Host "LLVM ${{ matrix.llvm }} is already installed."
+          } else {
+            Write-Host "Installing LLVM ${{ matrix.llvm }}..."
+            Install-WinGetPackage -Id LLVM.LLVM -Version ${{ matrix.llvm }} -Source winget -MatchOption Equals -Mode Silent -Force
+          }
+          clang --version
+
       - name: Install WDK (${{ matrix.wdk }})
         run: |
-          if (!(winget list --exact --source winget --id ${{ matrix.wdk }})[-1].contains("${{ matrix.wdk }}")) {
-            winget install --disable-interactivity --source winget --exact --id ${{ matrix.wdk }}
+          if ((Get-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals).Id -eq '${{ matrix.wdk }}') {
+            Write-Host "${{ matrix.wdk }} is already installed. Attempting to update..."
+            Update-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
+          } else {
+            Write-Host "Installing ${{ matrix.wdk }}..."
+            Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
           }
 
       - name: Install Rust Toolchain (${{ matrix.rust_toolchain }})
@@ -90,7 +107,7 @@ jobs:
       - name: Install Cargo Udeps
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps
+          tool: cargo-udeps@0.1.48
 
       - name: Run Cargo Udeps
         run: cargo +nightly udeps --locked --all-targets


### PR DESCRIPTION
accompanies https://github.com/microsoft/windows-drivers-rs/pull/175

This PR:

* adds an additional CI matrix entry to test on specific LLVM versions instead of using whatever version is in the [github windows runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
    * currently only testing on latest LLVM 17
* switches all winget commands to use the new winget powershell module so its easier to parse output