### PR TITLE
Do not use Class Sample in .inx file

### DIFF
--- a/general/echo/kmdf/driver/DriverSync/echo_2.inx
+++ b/general/echo/kmdf/driver/DriverSync/echo_2.inx
@@ -7,8 +7,8 @@
 
 [Version]
 Signature   = "$WINDOWS NT$"
-Class       = Sample
-ClassGuid   = {78A1C341-4539-11d3-B88D-00C04FAD5171}
+Class       = SampleClass
+ClassGuid   = {85eaace9-8bc8-4063-b56c-f078b7671d53}
 Provider    = %ProviderString%
 PnpLockDown = 1
 


### PR DESCRIPTION
Fixes this error when running cargo make in EWDK: Windows 11, version 24H2 EWDK (released May 22, 2024) with Visual Studio Buildtools 17.8.6, 26100

```
Validating echo_2.inf
ERROR(1284) in C:\Users\xxx\Documents\develop\Windows-rust-driver-samples\target\debug\echo_2.inf, line 10: Class "Sample" is reserved for use by Microsoft.
ERROR(1285) in C:\Users\xxx\Documents\develop\Windows-rust-driver-samples\target\debug\echo_2.inf, line 28: Cannot specify [ClassInstall32] section for Microsoft-defined class.
INF is NOT VALID
```