### PR TITLE
refactor: fix clippy::unnecessary_semicolon lints

### DIFF
--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -197,7 +197,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
             return status;
         }
         Ok(spin_lock) => unsafe { (*queue_context).spin_lock = spin_lock },
-    };
+    }
 
     // Create the Queue timer
     //
@@ -219,7 +219,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
             return status;
         }
         Ok(wdftimer) => unsafe { (*queue_context).timer = wdftimer },
-    };
+    }
 
     STATUS_SUCCESS
 }


### PR DESCRIPTION
This pull request includes a couple of small changes to the `echo_queue_initialize` function in the `queue.rs` file. The changes involve fixing the syntax by removing unnecessary semicolons after match arms. 

Changes in `queue.rs`:

* Removed unnecessary semicolons after match arms in the `echo_queue_initialize` function to correct the syntax. [[1]](diffhunk://#diff-3fa4fd0739bebabfd9aed2ff13f6c3f08cb0e0fa56a8196696acc05a834dc31fL200-R200) [[2]](diffhunk://#diff-3fa4fd0739bebabfd9aed2ff13f6c3f08cb0e0fa56a8196696acc05a834dc31fL222-R222)