### PR TITLE
chore: use cargo-wdk to build & package samples on the CI pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
 
       # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
       - name: Install cargo-wdk binary
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force --profile ${{matrix.cargo_profile}}
 
       - name: Build and Package Sample Drivers in the workspace with cargo-wdk
         run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
-    continue-on-error: true # Since remaining jobs are just cancelled on one job failure, we could allow them to finish and report the errors
     strategy:
+      fail-fast: false # Allow all matrix variants to complete even if some fail
       matrix:
         wdk:
           - Microsoft.WindowsWDK.10.0.22621 # NI WDK
@@ -87,10 +87,10 @@ jobs:
       - name: Build and Package Sample Drivers
         run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }}
 
-      # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
+      # Steps to use cargo-wdk to build and package drivers (uses cargo-wdk at specific commit https://github.com/microsoft/windows-drivers-rs/commit/5b9aa0a14e385daf5217c0f5232bcd4d3f4780a6)
       - name: Install cargo-wdk binary
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force --profile ${{matrix.cargo_profile}}
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/microsoft/windows-drivers-rs.git cargo-wdk --branch main --rev 5b9aa0a14e385daf5217c0f5232bcd4d3f4780a6 --locked --force
 
-      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
+      - name: Build and Package Sample Drivers with cargo-wdk
         run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
         continue-on-error: true # cargo-wdk build fails for a known reason

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,12 +34,10 @@ jobs:
           - release
 
         target_triple:
-          - x86_64-pc-windows-msvc
-          - aarch64-pc-windows-msvc
-
-        target_arch:
-          - x64
-          - arm64
+          - name: x86_64-pc-windows-msvc
+            arch: x64
+          - name: aarch64-pc-windows-msvc
+            arch: arm64
 
     steps:
       - name: Checkout Repository
@@ -74,19 +72,19 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_toolchain }}
-          targets: ${{ matrix.target_triple }}
+          targets: ${{ matrix.target_triple.name }}
 
       - name: Run Cargo Build
-        run: cargo +${{ matrix.rust_toolchain }} build --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --workspace
+        run: cargo +${{ matrix.rust_toolchain }} build --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --workspace
 
       # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
       - name: Install cargo-wdk binary
-        if: ${{ matrix.target_arch != 'arm64' }}
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --force
+        if: ${{ matrix.target_triple.arch != 'arm64' }}
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --force
 
       - name: Build and Package Sample Drivers in the workspace with cargo-wdk
-        if: ${{ matrix.target_arch != 'arm64' }}
-        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_arch }}
+        if: ${{ matrix.target_triple.arch != 'arm64' }}
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
 
       # Steps to use cargo-make to build and package drivers
       - name: Install Cargo Make
@@ -95,4 +93,4 @@ jobs:
           tool: cargo-make
 
       - name: Build and Package Sample Drivers
-        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}
+        run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
+    continue-on-error: true # Since remaining jobs are just cancelled on one job failure, we could allow them to finish and report the errors
     strategy:
       matrix:
         wdk:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,6 +79,14 @@ jobs:
       - name: Run Cargo Build
         run: cargo +${{ matrix.rust_toolchain }} build --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --workspace
 
+      # Steps to use cargo-wdk to build and package drivers
+      - name: Install cargo-wdk binary
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --force
+
+      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_arch }}
+
+      # Steps to use cargo-make to build and package drivers
       - name: Install Cargo Make
         uses: taiki-e/install-action@v2
         with:
@@ -86,10 +94,3 @@ jobs:
 
       - name: Build and Package Sample Drivers
         run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}
-
-      # Steps to use cargo-wdk to build and package drivers
-      - name: Install cargo-wdk binary
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --force
-
-      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
-        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_arch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
 
         target_triple:
           - name: x86_64-pc-windows-msvc
-            arch: x64
+            arch: amd64
           - name: aarch64-pc-windows-msvc
             arch: arm64
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,11 +80,9 @@ jobs:
 
       # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
       - name: Install cargo-wdk binary
-        if: ${{ matrix.target_triple.arch != 'arm64' }}
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --force
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force
 
       - name: Build and Package Sample Drivers in the workspace with cargo-wdk
-        if: ${{ matrix.target_triple.arch != 'arm64' }}
         run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
         continue-on-error: true # cargo-wdk build fails for a known reason
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,11 +79,13 @@ jobs:
       - name: Run Cargo Build
         run: cargo +${{ matrix.rust_toolchain }} build --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --workspace
 
-      # Steps to use cargo-wdk to build and package drivers
+      # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
       - name: Install cargo-wdk binary
+        if: ${{ matrix.target_arch != 'arm64' }}
         run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --force
 
       - name: Build and Package Sample Drivers in the workspace with cargo-wdk
+        if: ${{ matrix.target_arch != 'arm64' }}
         run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_arch }}
 
       # Steps to use cargo-make to build and package drivers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,7 @@ jobs:
       - name: Build and Package Sample Drivers in the workspace with cargo-wdk
         if: ${{ matrix.target_triple.arch != 'arm64' }}
         run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
+        continue-on-error: true # cargo-wdk build fails for a known reason
 
       # Steps to use cargo-make to build and package drivers
       - name: Install Cargo Make

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,14 +78,6 @@ jobs:
       - name: Run Cargo Build
         run: cargo +${{ matrix.rust_toolchain }} build --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }} --workspace
 
-      # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
-      - name: Install cargo-wdk binary
-        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force --profile ${{matrix.cargo_profile}}
-
-      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
-        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
-        continue-on-error: true # cargo-wdk build fails for a known reason
-
       # Steps to use cargo-make to build and package drivers
       - name: Install Cargo Make
         uses: taiki-e/install-action@v2
@@ -94,3 +86,11 @@ jobs:
 
       - name: Build and Package Sample Drivers
         run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple.name }}
+
+      # Steps to use cargo-wdk to build and package drivers (skipping for arm64 as the base runner image is x86_64)
+      - name: Install cargo-wdk binary
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --force --profile ${{matrix.cargo_profile}}
+
+      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_triple.arch }}
+        continue-on-error: true # cargo-wdk build fails for a known reason

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,10 @@ jobs:
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc
 
+        target_arch:
+          - x64
+          - arm64
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -82,3 +86,10 @@ jobs:
 
       - name: Build and Package Sample Drivers
         run: cargo make default +${{ matrix.rust_toolchain }} --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }}
+
+      # Steps to use cargo-wdk to build and package drivers
+      - name: Install cargo-wdk binary
+        run: cargo +${{ matrix.rust_toolchain }} install --git https://github.com/svasista-ms/windows-drivers-rs.git cargo-wdk --branch integrate-cargo-wdk --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --force
+
+      - name: Build and Package Sample Drivers in the workspace with cargo-wdk
+        run: cargo +${{ matrix.rust_toolchain }} wdk build --profile ${{ matrix.cargo_profile }} --target-arch ${{ matrix.target_arch }}


### PR DESCRIPTION
This PR aims to use cargo-wdk to build and package the driver samples in the repository on the CI pipeline.
Changes:
1. Added `continue-on-error = true` to the build job. Without this change, one job failure cancels all the other jobs triggered in the matrix. Since other jobs are being cancelled, we won't be able to know the possible failures/successes of those jobs while most of them have executed 70% of the steps at any given time.
2. Added `continue-on-error = true` to the "Build and Package Sample Drivers in the workspace with cargo-wdk" step as `cargo-wdk` fails for known reasons due to a mix of sample and non-sample drivers in the workspace. `cargo-wdk` currently can work with one kind of setup, either all are sample drivers or none. An [ issue](https://github.com/microsoft/windows-drivers-rs/issues/361) is created on WDR to address this.  
3. Note: The `cargo-wdk` used in the pipeline is taken from https://github.com/svasista-ms/windows-drivers-rs and from `integrate-cargo-wdk` branch as [this PR](https://github.com/microsoft/windows-drivers-rs/pull/306) is still not merged. This pipeline needs to get updated with `cargo-wdk` from https://github.com/microsoft/windows-drivers-repo once it is merged.

### About cargo-wdk
`cargo-wdk` is a Command-Line Interface (CLI) utility that can be used to create and build Windows driver projects that depend on the WDK and windows-drivers-rs platform. It aims to streamline management of Rust drivers. It provides an easy and a consistent way to get started with Rust driver projects and build them using simple commands. It eliminates a lengthy setup process and also the need to maintain additional files/tools (Makefiles for cargo-make) to build/package the drivers.

Note: cargo-wdk is yet to be merged into windows-drivers-rs repo and it under review [here](https://github.com/microsoft/windows-drivers-rs/pull/306)