### PR TITLE
chore: update to latest WDR release

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Cargo Udeps
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps@0.1.48
+          tool: cargo-udeps@0.1.55
 
       - name: Run Cargo Udeps
         run: cargo +nightly udeps --locked --all-targets

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -104,17 +104,13 @@ jobs:
             Install-WinGetPackage -Id ${{ matrix.wdk }} -Source winget -MatchOption Equals -Mode Silent -Force
           }
 
-      - name: Install Rust Toolchain (Nightly)
-        # Cargo udeps only supports running on nightly due to reliance on unstable dep-info feature: https://github.com/est31/cargo-udeps/issues/113, https://github.com/est31/cargo-udeps/issues/136
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Cargo Udeps
+      - name: Install Cargo Machete
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps@0.1.55
+          tool: cargo-machete
 
-      - name: Run Cargo Udeps
-        run: cargo +nightly udeps --locked --all-targets
-
-      - name: Run Cargo Udeps (--features nightly)
-        run: cargo +nightly udeps --locked --all-targets --features nightly
+      - name: Run Cargo Machete
+        run: cargo machete --skip-target-dir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -77,7 +77,7 @@ jobs:
         if: matrix.rust_toolchain == 'nightly'
         run: cargo +${{ matrix.rust_toolchain }} clippy --locked --profile ${{ matrix.cargo_profile }} --target ${{ matrix.target_triple }} --all-targets --features nightly -- -D warnings
 
-  udeps:
+  machete:
     name: Detect Unused Cargo Dependencies
     runs-on: windows-latest
     strategy:
@@ -113,4 +113,4 @@ jobs:
           tool: cargo-machete
 
       - name: Run Cargo Machete
-        run: cargo machete --skip-target-dir
+        run: cargo machete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,22 +61,20 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -85,7 +83,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -114,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -128,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.22"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -268,6 +265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+dependencies = [
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,24 +285,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -317,15 +306,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -422,9 +402,9 @@ checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -432,18 +412,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -494,9 +474,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -513,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -524,10 +504,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
-name = "semver"
-version = "1.0.21"
+name = "scratch"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -554,11 +540,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -585,12 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,9 +579,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,18 +590,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -738,10 +719,11 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wdk"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80cc00b5c587d3a43f489350a797a258eefca5ab0bb5d0d5b56d4ce09ab42f2"
+checksum = "e54179fc537fa0c8da80cc7c513787a4f408331f2f7d7b1c31b0fafd39eee516"
 dependencies = [
+ "cfg-if",
  "tracing",
  "tracing-subscriber",
  "wdk-build",
@@ -750,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "wdk-alloc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd1c139c6b9c05475bc7e8b356d4fbc252954d685691d70cfaec8b42c41b72d"
+checksum = "5c349e2078aba5359ea06d97ab5e85bfe178ac70a97407f54a1090165c732196"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -762,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "wdk-build"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b276786d848e5ab00e021968e89cfdc591938b69741a3733e7e3d91b23f547f"
+checksum = "5e3f0b26b6fa28e8f68a01a9d93c13433311a24e477c614659bf9e72fd9f7e26"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -773,9 +755,9 @@ dependencies = [
  "cfg-if",
  "clap",
  "clap-cargo",
- "lazy_static",
  "paste",
  "rustversion",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -785,33 +767,38 @@ dependencies = [
 
 [[package]]
 name = "wdk-macros"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f069b2e89e5a3327e84bc2f672f7f35d94059da590666d7d605f33f2ae2fa3"
+checksum = "f9e371a885e23b11de5b579368571f2403f1767b629008ad7de462f84db01d28"
 dependencies = [
- "itertools 0.13.0",
+ "cfg-if",
+ "fs4",
+ "itertools",
  "proc-macro2",
  "quote",
+ "scratch",
+ "serde",
+ "serde_json",
  "syn",
 ]
 
 [[package]]
 name = "wdk-panic"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba15dc2294f5c87df4b30218d93fb459ac8484a45683d4ad06fc0243e58736c"
+checksum = "9e2b724a14f327229f37923f5edaacf83aab295762b94b6a391fa14cd9eac550"
 
 [[package]]
 name = "wdk-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f974829a3b0b362723d55f0d05d8f1715bb7a88297558c4127f69d85bbff7e"
+checksum = "0afb20bec3a2627f0fd0ead3bc76f5ad7dcb9fa87e51f7851d08f74f29a3625f"
 dependencies = [
  "anyhow",
  "bindgen",
  "cargo_metadata",
  "cc",
- "lazy_static",
+ "cfg-if",
  "rustversion",
  "serde_json",
  "thiserror",
@@ -819,18 +806,6 @@ dependencies = [
  "tracing-subscriber",
  "wdk-build",
  "wdk-macros",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ lto = true
 [workspace.dependencies]
 anyhow = "1.0.89"
 paste = "1.0.14"
-wdk = "0.3.0"
-wdk-alloc = "0.3.0"
-wdk-build = "0.3.0"
-wdk-panic = "0.3.0"
-wdk-sys = "0.3.0"
+wdk = "0.3.1"
+wdk-alloc = "0.3.1"
+wdk-build = "0.4.0"
+wdk-panic = "0.3.1"
+wdk-sys = "0.4.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,7 +11,7 @@ load_script = '''
 #!@rust
 //! ```cargo
 //! [dependencies]
-//! wdk-build = "0.3.0"
+//! wdk-build = "0.4.0"
 //! ```
 #![allow(unused_doc_comments)]
 

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -4,7 +4,6 @@
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
-    APC_LEVEL,
     NTSTATUS,
     STATUS_SUCCESS,
     WDFDEVICE,
@@ -24,7 +23,6 @@ use crate::{
     wdf_object_context::wdf_get_context_type_info,
     wdf_object_get_device_context,
     DeviceContext,
-    KeGetCurrentIrql,
     GUID_DEVINTERFACE_ECHO,
     WDF_DEVICE_CONTEXT_TYPE_INFO,
     WDF_OBJECT_ATTRIBUTES_SIZE,
@@ -64,7 +62,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
         call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetPnpPowerEventCallbacks,
             device_init,
-            &mut pnp_power_callbacks
+            &raw mut pnp_power_callbacks
         );
     };
 
@@ -80,7 +78,7 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
         call_unsafe_wdf_function_binding!(
             WdfDeviceInitSetRequestAttributes,
             device_init,
-            &mut attributes
+            &raw mut attributes
         );
     };
 
@@ -97,8 +95,8 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
         call_unsafe_wdf_function_binding!(
             WdfDeviceCreate,
             (core::ptr::addr_of_mut!(device_init)).cast(),
-            &mut attributes,
-            &mut device,
+            &raw mut attributes,
+            &raw mut device,
         )
     };
 

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -4,8 +4,6 @@
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
-    ntddk::KeGetCurrentIrql,
-    APC_LEVEL,
     DRIVER_OBJECT,
     NTSTATUS,
     PCUNICODE_STRING,
@@ -66,7 +64,7 @@ extern "system" fn driver_entry(
             driver as PDRIVER_OBJECT,
             registry_path,
             WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
+            &raw mut driver_config,
             driver_handle_output,
         )
     };
@@ -130,7 +128,7 @@ fn echo_print_driver_version() -> NTSTATUS {
             WdfStringCreate,
             core::ptr::null_mut(),
             WDF_NO_OBJECT_ATTRIBUTES,
-            &mut string
+            &raw mut string
         )
     };
     if !nt_success(nt_status) {
@@ -153,7 +151,7 @@ fn echo_print_driver_version() -> NTSTATUS {
     }
 
     unsafe {
-        call_unsafe_wdf_function_binding!(WdfStringGetUnicodeString, string, &mut us);
+        call_unsafe_wdf_function_binding!(WdfStringGetUnicodeString, string, &raw mut us);
     };
     let driver_version = String::from_utf16_lossy(unsafe {
         slice::from_raw_parts(
@@ -175,7 +173,7 @@ fn echo_print_driver_version() -> NTSTATUS {
         MinorVersion: 0,
     };
 
-    if unsafe { call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &mut ver) }
+    if unsafe { call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &raw mut ver) }
         > 0
     {
         println!("Yes, framework version is 1.0");

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -173,8 +173,9 @@ fn echo_print_driver_version() -> NTSTATUS {
         MinorVersion: 0,
     };
 
-    if unsafe { call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &raw mut ver) }
-        > 0
+    if unsafe {
+        call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &raw mut ver)
+    } > 0
     {
         println!("Yes, framework version is 1.0");
     } else {

--- a/general/echo/kmdf/driver/DriverSync/src/lib.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/lib.rs
@@ -47,7 +47,6 @@ use wdk::wdf;
 use wdk_alloc::WdkAllocator;
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
-    ntddk::KeGetCurrentIrql,
     GUID,
     NTSTATUS,
     PVOID,

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -6,8 +6,7 @@ use core::sync::atomic::Ordering;
 use wdk::{nt_success, paged_code, println, wdf};
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
-    ntddk::{ExAllocatePool2, ExFreePool, KeGetCurrentIrql},
-    APC_LEVEL,
+    ntddk::{ExAllocatePool2, ExFreePool},
     NTSTATUS,
     POOL_FLAG_NON_PAGED,
     SIZE_T,
@@ -163,9 +162,9 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
         call_unsafe_wdf_function_binding!(
             WdfIoQueueCreate,
             device,
-            &mut queue_config,
-            &mut attributes,
-            &mut queue
+            &raw mut queue_config,
+            &raw mut attributes,
+            &raw mut queue
         )
     };
 
@@ -449,7 +448,7 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
     // Get the request memory
     unsafe {
         nt_status =
-            call_unsafe_wdf_function_binding!(WdfRequestRetrieveOutputMemory, request, &mut memory);
+            call_unsafe_wdf_function_binding!(WdfRequestRetrieveOutputMemory, request, &raw mut memory);
 
         if !nt_success(nt_status) {
             println!("echo_evt_io_read Could not get request memory buffer {nt_status:#010X}");
@@ -543,7 +542,7 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
     // Get the memory buffer
     unsafe {
         status =
-            call_unsafe_wdf_function_binding!(WdfRequestRetrieveInputMemory, request, &mut memory);
+            call_unsafe_wdf_function_binding!(WdfRequestRetrieveInputMemory, request, &raw mut memory);
         if !nt_success(status) {
             println!("echo_evt_io_write Could not get request memory buffer {status:#010X}");
             call_unsafe_wdf_function_binding!(WdfRequestComplete, request, status);

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -447,8 +447,11 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 
     // Get the request memory
     unsafe {
-        nt_status =
-            call_unsafe_wdf_function_binding!(WdfRequestRetrieveOutputMemory, request, &raw mut memory);
+        nt_status = call_unsafe_wdf_function_binding!(
+            WdfRequestRetrieveOutputMemory,
+            request,
+            &raw mut memory
+        );
 
         if !nt_success(nt_status) {
             println!("echo_evt_io_read Could not get request memory buffer {nt_status:#010X}");
@@ -541,8 +544,11 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
 
     // Get the memory buffer
     unsafe {
-        status =
-            call_unsafe_wdf_function_binding!(WdfRequestRetrieveInputMemory, request, &raw mut memory);
+        status = call_unsafe_wdf_function_binding!(
+            WdfRequestRetrieveInputMemory,
+            request,
+            &raw mut memory
+        );
         if !nt_success(status) {
             println!("echo_evt_io_write Could not get request memory buffer {status:#010X}");
             call_unsafe_wdf_function_binding!(WdfRequestComplete, request, status);

--- a/tools/dv/kmdf/fail_driver_pool_leak/src/driver.rs
+++ b/tools/dv/kmdf/fail_driver_pool_leak/src/driver.rs
@@ -4,8 +4,7 @@
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
-    ntddk::{ExAllocatePool2, KeGetCurrentIrql},
-    APC_LEVEL,
+    ntddk::ExAllocatePool2,
     DRIVER_OBJECT,
     NTSTATUS,
     PCUNICODE_STRING,
@@ -84,7 +83,7 @@ extern "system" fn driver_entry(
             driver as PDRIVER_OBJECT,
             registry_path,
             WDF_NO_OBJECT_ATTRIBUTES,
-            &mut driver_config,
+            &raw mut driver_config,
             driver_handle_output,
         )
     };
@@ -133,9 +132,9 @@ extern "C" fn evt_driver_device_add(
     let mut nt_status = unsafe {
         call_unsafe_wdf_function_binding!(
             WdfDeviceCreate,
-            &mut device_init,
-            &mut attributes,
-            &mut device,
+            &raw mut device_init,
+            &raw mut attributes,
+            &raw mut device,
         )
     };
 


### PR DESCRIPTION
Updated the Cargo configuration to point to the [latest WDR release](https://github.com/microsoft/windows-drivers-rs/releases).

This driver was tested with the WDR release as a validation step in the [release PR](https://github.com/microsoft/windows-drivers-rs/pull/343).