### PR TITLE
fix: re-enable tests on cdylib crates

### DIFF
--- a/general/echo/kmdf/driver/DriverSync/Cargo.toml
+++ b/general/echo/kmdf/driver/DriverSync/Cargo.toml
@@ -10,8 +10,6 @@ publish.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
-# Tests from root driver crates must be excluded since there's no way to prevent linker args from being passed to their unit tests: https://github.com/rust-lang/cargo/issues/12663
-test = false
 
 [dependencies]
 paste.workspace = true

--- a/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
+++ b/tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml
@@ -11,8 +11,6 @@ license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
-# Tests from root driver crates must be excluded since there's no way to prevent linker args from being passed to their unit tests: https://github.com/rust-lang/cargo/issues/12663
-test = false
 
 [dependencies]
 wdk.workspace = true


### PR DESCRIPTION
related to microsoft/windows-drivers-rs#327

This pull request removes the exclusion of unit tests from the root driver crates in two `Cargo.toml` files. This change allows unit tests to be included, despite the previous concern about linker arguments being passed to them.

Changes to `Cargo.toml` files:

* [`general/echo/kmdf/driver/DriverSync/Cargo.toml`](diffhunk://#diff-594b6485cb9d49e82d5d7e95521a2b7b92be5f8e4505dfd72867456471c28615L13-L14): Removed the line excluding unit tests (`test = false`) from the root driver crate.
* [`tools/dv/kmdf/fail_driver_pool_leak/Cargo.toml`](diffhunk://#diff-36617169414e5fe53d6a7e616bd5b16dd19771464585455a8c9ac1becc4c271aL14-L15): Removed the line excluding unit tests (`test = false`) from the root driver crate.