### PR TITLE
ci: add concurrency control to workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 11 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/cargo-audit.yaml
+++ b/.github/workflows/cargo-audit.yaml
@@ -11,7 +11,7 @@ on:
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -8,7 +8,7 @@ on:
     - cron: 0 11 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 11 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/.github/workflows/github-dependency-review.yaml
+++ b/.github/workflows/github-dependency-review.yaml
@@ -6,7 +6,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 11 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.compare || github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Closes #38 

Cancels in-progress workflows/jobs for the `build` workflow when new events are triggered on the same branch

Summary of changes:
- Added `concurrency` section to the `build.yaml` workflow
- Added `cancel-in-progress: true` to cancel any currently running job or workflow in the same concurrency group.