### PR TITLE
ci: adopt install-cargo-tool fallback and pinned taplo-cli from windows-drivers-rs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
 
       # Steps to use cargo-make to build and package drivers
       - name: Install Cargo Make
-        uses: taiki-e/install-action@v2
+        uses: ./.github/actions/install-cargo-tool
         with:
           tool: cargo-make
 

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -36,11 +36,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Checkout windows-drivers-rs actions
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/windows-drivers-rs
+          ref: main
+          path: _temp/windows-drivers-rs
+          sparse-checkout: |
+            .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Copy actions to workspace
+        shell: pwsh
+        run: Copy-Item -Recurse -Force _temp/windows-drivers-rs/.github/actions .github/
+
       - name: Install Rust Toolchain (Stable)
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install taplo-cli
-        uses: taiki-e/install-action@v2
+        uses: ./.github/actions/install-cargo-tool
         with:
           tool: taplo-cli
 

--- a/.github/workflows/code-formatting-check.yaml
+++ b/.github/workflows/code-formatting-check.yaml
@@ -36,27 +36,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Checkout windows-drivers-rs actions
-        uses: actions/checkout@v4
-        with:
-          repository: microsoft/windows-drivers-rs
-          ref: main
-          path: _temp/windows-drivers-rs
-          sparse-checkout: |
-            .github/actions
-          sparse-checkout-cone-mode: false
-
-      - name: Copy actions to workspace
-        shell: pwsh
-        run: Copy-Item -Recurse -Force _temp/windows-drivers-rs/.github/actions .github/
-
       - name: Install Rust Toolchain (Stable)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install taplo-cli
-        uses: ./.github/actions/install-cargo-tool
+      # Using cache-cargo-install-action to cache the compiled binary.
+      # Once taplo ships a release with field-level `keys` matching, this can
+      # be simplified back to install-action with a normal version pin.
+      - name: Install taplo-cli from pinned revision b673b44d
+        uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: taplo-cli
+          git: https://github.com/tamasfe/taplo
+          rev: b673b44d
+          locked: true
+        env:
+          RUSTFLAGS: ""
 
       - run: taplo fmt --check --diff
         name: Check TOML files formatting

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -112,11 +112,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Checkout windows-drivers-rs actions
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/windows-drivers-rs
+          ref: main
+          path: _temp/windows-drivers-rs
+          sparse-checkout: |
+            .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Copy actions to workspace
+        shell: pwsh
+        run: Copy-Item -Recurse -Force _temp/windows-drivers-rs/.github/actions .github/
+
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Cargo Machete
-        uses: taiki-e/install-action@v2
+        uses: ./.github/actions/install-cargo-tool
         with:
           tool: cargo-machete
 


### PR DESCRIPTION
Adopts CI improvements from windows-drivers-rs:

1. Replaces `taiki-e/install-action@v2` for `cargo-make` (in `build.yaml`) and `cargo-machete` (in `lint.yaml`) with the `install-cargo-tool` composite action from microsoft/windows-drivers-rs#625. This adds automatic `cargo install` fallback when `install-action` silently fails on `windows-11-arm` runners under WoW64 arm64 emulation (see actions/partner-runner-images#169). For jobs that didn't already sparse-checkout shared actions (`machete` in `lint.yaml`), adds the checkout and copy steps.

2. Switches `taplo-cli` installation in `code-formatting-check.yaml` to `taiki-e/cache-cargo-install-action@v3` with the same pinned git revision (`b673b44d`) used by windows-drivers-rs.