### PR TITLE
refactor: remove magic numbers

### DIFF
--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -30,18 +30,11 @@ use crate::{
     WDF_REQUEST_CONTEXT_TYPE_INFO,
 };
 
-/// Number of 100-nanosecond intervals in one millisecond. WDF relative times
-/// are expressed in 100-nanosecond units, so this converts a millisecond delay
-/// into the units WDF expects.
-const RELATIVE_100_NS_INTERVALS_PER_MS: i64 = 10_000;
-
-/// Delay, in milliseconds, before the periodic timer first fires once the
-/// device has started.
-const START_TIMER_DUE_TIME_MS: i64 = 100;
+use core::time::Duration;
 
 /// 100ms relative time (in 100-nanosecond units). The negative sign marks the
 /// value as a relative (rather than absolute) timeout.
-const WDF_REL_TIMEOUT_IN_MS: i64 = -START_TIMER_DUE_TIME_MS * RELATIVE_100_NS_INTERVALS_PER_MS;
+const WDF_REL_TIMEOUT_100_MS: i64 = -( ( Duration::from_millis(100).as_nanos() / 100 ) as i64 );
 
 /// Worker routine called to create a device and its software resources.
 ///
@@ -175,7 +168,7 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
     // into low power state.
     unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) };
 
-    let due_time: i64 = WDF_REL_TIMEOUT_IN_MS;
+    let due_time: i64 = WDF_REL_TIMEOUT_100_MS;
 
     let _ = unsafe { (*queue_context).timer.start(due_time) };
 

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // License: MIT OR Apache-2.0
 
+use core::time::Duration;
+
 use wdk::{nt_success, paged_code, println};
 use wdk_sys::{
     call_unsafe_wdf_function_binding,
@@ -29,8 +31,6 @@ use crate::{
     WDF_PNPPOWER_EVENT_CALLBACKS_SIZE,
     WDF_REQUEST_CONTEXT_TYPE_INFO,
 };
-
-use core::time::Duration;
 
 /// Worker routine called to create a device and its software resources.
 ///
@@ -148,9 +148,22 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
 ///
 /// * `NTSTATUS` - Failures will result in the device stack being torn down.
 extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTATUS {
-    /// 100ms relative time (in 100-nanosecond units). The negative sign marks the
-    /// value as a relative (rather than absolute) timeout.
-    const WDF_REL_TIMEOUT_100_MS: i64 = -( ( Duration::from_millis(100).as_nanos() / 100 ) as i64 );
+    /// 100ms relative time (in 100-nanosecond units). The negative sign marks
+    /// the value as a relative (rather than absolute) timeout.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "100ms in 100-nanosecond units is known to fit in i64"
+    )]
+    const WDF_REL_TIMEOUT_100_MS: i64 = {
+        const UNITS: u128 = Duration::from_millis(100).as_nanos() / 100;
+        const {
+            assert!(
+                UNITS <= i64::MAX as u128,
+                "1,000,000 should fit in i64"
+            );
+        };
+        -(UNITS as i64)
+    };
 
     // Restart the queue and the periodic timer. We stopped them before going
     // into low power state.

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -30,8 +30,18 @@ use crate::{
     WDF_REQUEST_CONTEXT_TYPE_INFO,
 };
 
-/// 100ms relative time (in nanoseconds units)
-const WDF_REL_TIMEOUT_IN_MS: i64 = -(100) * (10000);
+/// Number of 100-nanosecond intervals in one millisecond. WDF relative times
+/// are expressed in 100-nanosecond units, so this converts a millisecond delay
+/// into the units WDF expects.
+const RELATIVE_100_NS_INTERVALS_PER_MS: i64 = 10_000;
+
+/// Delay, in milliseconds, before the periodic timer first fires once the
+/// device has started.
+const START_TIMER_DUE_TIME_MS: i64 = 100;
+
+/// 100ms relative time (in 100-nanosecond units). The negative sign marks the
+/// value as a relative (rather than absolute) timeout.
+const WDF_REL_TIMEOUT_IN_MS: i64 = -START_TIMER_DUE_TIME_MS * RELATIVE_100_NS_INTERVALS_PER_MS;
 
 /// Worker routine called to create a device and its software resources.
 ///

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -148,18 +148,22 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
 ///
 /// * `NTSTATUS` - Failures will result in the device stack being torn down.
 extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTATUS {
-    /// 100ms relative time (in 100-nanosecond units). The negative sign marks
-    /// the value as a relative (rather than absolute) timeout.
+    /// 100ms relative due time for a WDF timer, in system time units.
     #[allow(
         clippy::cast_possible_truncation,
         reason = "100ms in 100-nanosecond units is known to fit in i64"
     )]
-    const WDF_REL_TIMEOUT_100_MS: i64 = {
-        const UNITS: u128 = Duration::from_millis(100).as_nanos() / 100;
+    const WDF_TIMER_DUE_TIME_100_MS: i64 = {
+        // System time units are 100-nanosecond intervals.
+        const SYSTEM_TIME_UNITS: u128 = Duration::from_millis(100).as_nanos() / 100;
         const {
-            assert!(UNITS <= i64::MAX as u128, "1,000,000 should fit in i64");
+            assert!(
+                SYSTEM_TIME_UNITS <= i64::MAX as u128,
+                "SYSTEM_TIME_UNITS should fit in i64"
+            );
         };
-        -(UNITS as i64)
+        // Negative marks the value as a relative (rather than absolute) timeout.
+        -(SYSTEM_TIME_UNITS as i64)
     };
 
     // Restart the queue and the periodic timer. We stopped them before going
@@ -178,7 +182,7 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
     // into low power state.
     unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) };
 
-    let due_time: i64 = WDF_REL_TIMEOUT_100_MS;
+    let due_time: i64 = WDF_TIMER_DUE_TIME_100_MS;
 
     let _ = unsafe { (*queue_context).timer.start(due_time) };
 

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -30,6 +30,9 @@ use crate::{
     WDF_REQUEST_CONTEXT_TYPE_INFO,
 };
 
+/// 100ms relative time (in nanoseconds units)
+const WDF_REL_TIMEOUT_IN_MS: i64 = -(100) * (10000);
+
 /// Worker routine called to create a device and its software resources.
 ///
 /// # Arguments:
@@ -162,7 +165,7 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
     // into low power state.
     unsafe { call_unsafe_wdf_function_binding!(WdfIoQueueStart, queue) };
 
-    let due_time: i64 = -(100) * (10000);
+    let due_time: i64 = WDF_REL_TIMEOUT_IN_MS;
 
     let _ = unsafe { (*queue_context).timer.start(due_time) };
 

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -32,10 +32,6 @@ use crate::{
 
 use core::time::Duration;
 
-/// 100ms relative time (in 100-nanosecond units). The negative sign marks the
-/// value as a relative (rather than absolute) timeout.
-const WDF_REL_TIMEOUT_100_MS: i64 = -( ( Duration::from_millis(100).as_nanos() / 100 ) as i64 );
-
 /// Worker routine called to create a device and its software resources.
 ///
 /// # Arguments:
@@ -152,6 +148,10 @@ pub fn echo_device_create(mut device_init: &mut WDFDEVICE_INIT) -> NTSTATUS {
 ///
 /// * `NTSTATUS` - Failures will result in the device stack being torn down.
 extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTATUS {
+    /// 100ms relative time (in 100-nanosecond units). The negative sign marks the
+    /// value as a relative (rather than absolute) timeout.
+    const WDF_REL_TIMEOUT_100_MS: i64 = -( ( Duration::from_millis(100).as_nanos() / 100 ) as i64 );
+
     // Restart the queue and the periodic timer. We stopped them before going
     // into low power state.
     let queue: WDFQUEUE;

--- a/general/echo/kmdf/driver/DriverSync/src/device.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/device.rs
@@ -157,10 +157,7 @@ extern "C" fn echo_evt_device_self_managed_io_start(device: WDFDEVICE) -> NTSTAT
     const WDF_REL_TIMEOUT_100_MS: i64 = {
         const UNITS: u128 = Duration::from_millis(100).as_nanos() / 100;
         const {
-            assert!(
-                UNITS <= i64::MAX as u128,
-                "1,000,000 should fit in i64"
-            );
+            assert!(UNITS <= i64::MAX as u128, "1,000,000 should fit in i64");
         };
         -(UNITS as i64)
     };

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -177,9 +177,15 @@ fn echo_print_driver_version() -> NTSTATUS {
         call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &raw mut ver)
     } > 0
     {
-        println!("Yes, framework version is {}.{}", ver.MajorVersion, ver.MinorVersion);
+        println!(
+            "Yes, framework version is {}.{}",
+            ver.MajorVersion, ver.MinorVersion
+        );
     } else {
-        println!("No, framework version is not {}.{}", ver.MajorVersion, ver.MinorVersion);
+        println!(
+            "No, framework version is not {}.{}",
+            ver.MajorVersion, ver.MinorVersion
+        );
     }
 
     STATUS_SUCCESS

--- a/general/echo/kmdf/driver/DriverSync/src/driver.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/driver.rs
@@ -177,9 +177,9 @@ fn echo_print_driver_version() -> NTSTATUS {
         call_unsafe_wdf_function_binding!(WdfDriverIsVersionAvailable, driver, &raw mut ver)
     } > 0
     {
-        println!("Yes, framework version is 1.0");
+        println!("Yes, framework version is {}.{}", ver.MajorVersion, ver.MinorVersion);
     } else {
-        println!("No, framework version is not 1.0");
+        println!("No, framework version is not {}.{}", ver.MajorVersion, ver.MinorVersion);
     }
 
     STATUS_SUCCESS

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -47,11 +47,27 @@ use crate::{
 /// Set max write length for testing
 const MAX_WRITE_LENGTH: usize = 1024 * 40;
 
-/// Set timer period in ms
-const TIMER_PERIOD: u32 = 1000 * 10;
+/// Number of milliseconds in one second.
+const MS_PER_SECOND: u32 = 1000;
 
-/// Non-zero char literal (of one to four chars) for pool tag used in ExAllocatePool2
+/// Watchdog timer period, in seconds.
+const TIMER_PERIOD_SECONDS: u32 = 10;
+
+/// Timer period in ms
+const TIMER_PERIOD: u32 = TIMER_PERIOD_SECONDS * MS_PER_SECOND;
+
+/// Non-zero char literal (of one to four chars) for pool tag used in
+/// `ExAllocatePool2`
 const MEMORY_TAG: u32 = u32::from_be_bytes(*b"sam1");
+
+/// Initial cancel/completion ownership count assigned to a new request. A
+/// claimant takes ownership by decrementing the count down to zero.
+const INITIAL_CANCEL_OWNERSHIP_COUNT: i32 = 1;
+
+/// Total ownership count held by the timer DPC once it has claimed completion
+/// of a request: the initial count plus the single increment it acquired via
+/// `echo_increment_request_cancel_ownership_count`.
+const TIMER_CLAIMED_OWNERSHIP_COUNT: i32 = INITIAL_CANCEL_OWNERSHIP_COUNT + 1;
 
 /// This routine will interlock increment a value only if the current value
 /// is greater then the floor value.
@@ -359,7 +375,8 @@ fn echo_set_current_request(request: WDFREQUEST, queue: WDFQUEUE) {
     // they will interlock decrement the count.  When the count reaches zero,
     // ownership has been acquired and the caller may complete the request.
     unsafe {
-        (*request_context).cancel_completion_ownership_count = AtomicI32::new(1);
+        (*request_context).cancel_completion_ownership_count =
+            AtomicI32::new(INITIAL_CANCEL_OWNERSHIP_COUNT);
     }
 
     // Defer the completion to another thread from the timer dpc
@@ -699,12 +716,12 @@ unsafe extern "C" fn echo_evt_timer_func(timer: WDFTIMER) {
             // currently racing with it), there is no need to use an interlocked
             // decrement to lower the cancel ownership count.
 
-            // 2 is the initial count we set when we initialized
-            // CancelCompletionOwnershipCount plus the call to
+            // TIMER_CLAIMED_OWNERSHIP_COUNT is the initial count we set when we
+            // initialized CancelCompletionOwnershipCount plus the call to
             // EchoIncrementRequestCancelOwnershipCount()
             (*request_context)
                 .cancel_completion_ownership_count
-                .fetch_sub(2, Ordering::SeqCst);
+                .fetch_sub(TIMER_CLAIMED_OWNERSHIP_COUNT, Ordering::SeqCst);
             complete_request = true;
         }
     }

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -44,24 +44,7 @@ use crate::{
     WDF_TIMER_CONFIG_SIZE,
 };
 
-/// Number of bytes in one kilobyte.
-const BYTES_PER_KB: usize = 1024;
-
-/// Max write length, in bytes, for testing
-const MAX_WRITE_LENGTH: usize = 40 * BYTES_PER_KB;
-
-/// Number of milliseconds in one second.
-const MS_PER_SECOND: u32 = 1000;
-
-/// Watchdog timer period, in seconds.
-const TIMER_PERIOD_SECONDS: u32 = 10;
-
-/// Timer period in ms
-const TIMER_PERIOD: u32 = TIMER_PERIOD_SECONDS * MS_PER_SECOND;
-
-/// Non-zero char literal (of one to four chars) for pool tag used in
-/// `ExAllocatePool2`
-const MEMORY_TAG: u32 = u32::from_be_bytes(*b"sam1");
+use core::time::Duration;
 
 /// Initial cancel/completion ownership count assigned to a new request. A
 /// claimant takes ownership by decrementing the count down to zero.
@@ -152,6 +135,9 @@ fn echo_interlocked_increment_gtzero(target: &AtomicI32) -> i32 {
 /// * `NTSTATUS`
 #[link_section = "PAGE"]
 pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
+    /// Timer period of 10 seconds in ms
+    const TIMER_PERIOD_10_S: u32 = Duration::from_secs(10).as_millis() as u32;
+
     paged_code!();
 
     let mut queue = WDF_NO_HANDLE as WDFQUEUE;
@@ -228,7 +214,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     let mut timer_config = WDF_TIMER_CONFIG {
         Size: WDF_TIMER_CONFIG_SIZE,
         EvtTimerFunc: Some(echo_evt_timer_func),
-        Period: TIMER_PERIOD,
+        Period: TIMER_PERIOD_10_S,
         AutomaticSerialization: u8::from(true),
         TolerableDelay: 0,
         ..WDF_TIMER_CONFIG::default()
@@ -541,6 +527,15 @@ extern "C" fn echo_evt_io_read(queue: WDFQUEUE, request: WDFREQUEST, mut length:
 ///
 /// * `VOID`
 extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: usize) {
+    /// Number of bytes in one kilobyte.
+    const BYTES_PER_KB: usize = 1024;
+    /// Max write length, in bytes, for testing
+    const MAX_WRITE_LENGTH: usize = 40 * BYTES_PER_KB;
+
+    /// Non-zero char literal (of one to four chars) for pool tag used in
+    /// `ExAllocatePool2`
+    const MEMORY_TAG: u32 = u32::from_be_bytes(*b"sam1");
+
     let mut memory = WDF_NO_HANDLE as WDFMEMORY;
     let mut status: NTSTATUS;
     let queue_context = unsafe { queue_get_context(queue as WDFOBJECT) };

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -213,7 +213,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     let mut timer_config = WDF_TIMER_CONFIG {
         Size: WDF_TIMER_CONFIG_SIZE,
         EvtTimerFunc: Some(echo_evt_timer_func),
-        Period: TIMER_PERIOD_MS, // 10 seconds, in milliseconds
+        Period: TIMER_PERIOD_MS,
         AutomaticSerialization: u8::from(true),
         TolerableDelay: 0,
         ..WDF_TIMER_CONFIG::default()

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // License: MIT OR Apache-2.0
 
-use core::sync::atomic::Ordering;
+use core::{sync::atomic::Ordering, time::Duration};
 
 use wdk::{nt_success, paged_code, println, wdf};
 use wdk_sys::{
@@ -124,6 +124,19 @@ fn echo_interlocked_increment_gtzero(target: &AtomicI32) -> i32 {
 /// * `NTSTATUS`
 #[link_section = "PAGE"]
 pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "10 seconds in millisecond units is known to fit in u32"
+    )]
+    const TIMER_PERIOD_MS: u32 = {
+        const MILLIS: u128 = Duration::from_secs(10).as_millis();
+        const {
+            assert!(MILLIS <= u32::MAX as u128, "10,000 should fit in u32");
+        };
+
+        MILLIS as u32
+    };
+
     paged_code!();
 
     let mut queue = WDF_NO_HANDLE as WDFQUEUE;
@@ -200,7 +213,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     let mut timer_config = WDF_TIMER_CONFIG {
         Size: WDF_TIMER_CONFIG_SIZE,
         EvtTimerFunc: Some(echo_evt_timer_func),
-        Period: 10_000, // 10 seconds, in milliseconds
+        Period: TIMER_PERIOD_MS, // 10 seconds, in milliseconds
         AutomaticSerialization: u8::from(true),
         TolerableDelay: 0,
         ..WDF_TIMER_CONFIG::default()

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -141,10 +141,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     const TIMER_PERIOD_10_S: u32 = {
         const MILLIS: u128 = Duration::from_secs(10).as_millis();
         const {
-            assert!(
-                MILLIS <= u32::MAX as u128,
-                "10,000 should fit in u32"
-            );
+            assert!(MILLIS <= u32::MAX as u128, "10,000 should fit in u32");
         };
         MILLIS as u32
     };

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // License: MIT OR Apache-2.0
 
-use core::{sync::atomic::Ordering, time::Duration};
+use core::sync::atomic::Ordering;
 
 use wdk::{nt_success, paged_code, println, wdf};
 use wdk_sys::{
@@ -43,15 +43,6 @@ use crate::{
     WDF_QUEUE_CONTEXT_TYPE_INFO,
     WDF_TIMER_CONFIG_SIZE,
 };
-
-/// Initial cancel/completion ownership count assigned to a new request. A
-/// claimant takes ownership by decrementing the count down to zero.
-const INITIAL_CANCEL_OWNERSHIP_COUNT: i32 = 1;
-
-/// Total ownership count held by the timer DPC once it has claimed completion
-/// of a request: the initial count plus the single increment it acquired via
-/// `echo_increment_request_cancel_ownership_count`.
-const TIMER_CLAIMED_OWNERSHIP_COUNT: i32 = INITIAL_CANCEL_OWNERSHIP_COUNT + 1;
 
 /// This routine will interlock increment a value only if the current value
 /// is greater then the floor value.
@@ -133,19 +124,6 @@ fn echo_interlocked_increment_gtzero(target: &AtomicI32) -> i32 {
 /// * `NTSTATUS`
 #[link_section = "PAGE"]
 pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
-    /// Timer period of 10 seconds in ms
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "10 seconds in millisecond units is known to fit in u32"
-    )]
-    const TIMER_PERIOD_10_S: u32 = {
-        const MILLIS: u128 = Duration::from_secs(10).as_millis();
-        const {
-            assert!(MILLIS <= u32::MAX as u128, "10,000 should fit in u32");
-        };
-        MILLIS as u32
-    };
-
     paged_code!();
 
     let mut queue = WDF_NO_HANDLE as WDFQUEUE;
@@ -222,7 +200,7 @@ pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     let mut timer_config = WDF_TIMER_CONFIG {
         Size: WDF_TIMER_CONFIG_SIZE,
         EvtTimerFunc: Some(echo_evt_timer_func),
-        Period: TIMER_PERIOD_10_S,
+        Period: 10_000, // 10 seconds, in milliseconds
         AutomaticSerialization: u8::from(true),
         TolerableDelay: 0,
         ..WDF_TIMER_CONFIG::default()
@@ -372,8 +350,7 @@ fn echo_set_current_request(request: WDFREQUEST, queue: WDFQUEUE) {
     // they will interlock decrement the count.  When the count reaches zero,
     // ownership has been acquired and the caller may complete the request.
     unsafe {
-        (*request_context).cancel_completion_ownership_count =
-            AtomicI32::new(INITIAL_CANCEL_OWNERSHIP_COUNT);
+        (*request_context).cancel_completion_ownership_count = AtomicI32::new(1);
     }
 
     // Defer the completion to another thread from the timer dpc
@@ -722,12 +699,11 @@ unsafe extern "C" fn echo_evt_timer_func(timer: WDFTIMER) {
             // currently racing with it), there is no need to use an interlocked
             // decrement to lower the cancel ownership count.
 
-            // TIMER_CLAIMED_OWNERSHIP_COUNT is the initial count we set when we
-            // initialized CancelCompletionOwnershipCount plus the call to
-            // EchoIncrementRequestCancelOwnershipCount()
+            // 2 = the initial ownership count (1) plus the one increment
+            // acquired via echo_increment_request_cancel_ownership_count.
             (*request_context)
                 .cancel_completion_ownership_count
-                .fetch_sub(TIMER_CLAIMED_OWNERSHIP_COUNT, Ordering::SeqCst);
+                .fetch_sub(2, Ordering::SeqCst);
             complete_request = true;
         }
     }

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -50,6 +50,9 @@ const MAX_WRITE_LENGTH: usize = 1024 * 40;
 /// Set timer period in ms
 const TIMER_PERIOD: u32 = 1000 * 10;
 
+/// Non-zero char literal (of one to four chars) for pool tag used in ExAllocatePool2
+const MEMORY_TAG: u32 = u32::from_be_bytes(*b"sam1");
+
 /// This routine will interlock increment a value only if the current value
 /// is greater then the floor value.
 ///
@@ -564,9 +567,8 @@ extern "C" fn echo_evt_io_write(queue: WDFQUEUE, request: WDFREQUEST, length: us
             (*queue_context).length = 0;
         }
 
-        // FIXME: Memory Tag
         (*queue_context).buffer =
-            ExAllocatePool2(POOL_FLAG_NON_PAGED, length as SIZE_T, 's' as u32);
+            ExAllocatePool2(POOL_FLAG_NON_PAGED, length as SIZE_T, MEMORY_TAG);
         if (*queue_context).buffer.is_null() {
             println!(
                 "echo_evt_io_write Could not allocate {:?} byte buffer",

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -44,8 +44,11 @@ use crate::{
     WDF_TIMER_CONFIG_SIZE,
 };
 
-/// Set max write length for testing
-const MAX_WRITE_LENGTH: usize = 1024 * 40;
+/// Number of bytes in one kilobyte.
+const BYTES_PER_KB: usize = 1024;
+
+/// Max write length, in bytes, for testing
+const MAX_WRITE_LENGTH: usize = 40 * BYTES_PER_KB;
 
 /// Number of milliseconds in one second.
 const MS_PER_SECOND: u32 = 1000;

--- a/general/echo/kmdf/driver/DriverSync/src/queue.rs
+++ b/general/echo/kmdf/driver/DriverSync/src/queue.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // License: MIT OR Apache-2.0
 
-use core::sync::atomic::Ordering;
+use core::{sync::atomic::Ordering, time::Duration};
 
 use wdk::{nt_success, paged_code, println, wdf};
 use wdk_sys::{
@@ -43,8 +43,6 @@ use crate::{
     WDF_QUEUE_CONTEXT_TYPE_INFO,
     WDF_TIMER_CONFIG_SIZE,
 };
-
-use core::time::Duration;
 
 /// Initial cancel/completion ownership count assigned to a new request. A
 /// claimant takes ownership by decrementing the count down to zero.
@@ -136,7 +134,20 @@ fn echo_interlocked_increment_gtzero(target: &AtomicI32) -> i32 {
 #[link_section = "PAGE"]
 pub unsafe fn echo_queue_initialize(device: WDFDEVICE) -> NTSTATUS {
     /// Timer period of 10 seconds in ms
-    const TIMER_PERIOD_10_S: u32 = Duration::from_secs(10).as_millis() as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "10 seconds in millisecond units is known to fit in u32"
+    )]
+    const TIMER_PERIOD_10_S: u32 = {
+        const MILLIS: u128 = Duration::from_secs(10).as_millis();
+        const {
+            assert!(
+                MILLIS <= u32::MAX as u128,
+                "10,000 should fit in u32"
+            );
+        };
+        MILLIS as u32
+    };
 
     paged_code!();
 

--- a/general/echo/kmdf/exe/src/main.rs
+++ b/general/echo/kmdf/exe/src/main.rs
@@ -70,18 +70,13 @@ static READER_TYPE: u32 = 1;
 static WRITER_TYPE: u32 = 2;
 static NUM_ASYNCH_IO: usize = 100;
 static BUFFER_SIZE: usize = 40 * 1024;
-/// Transfer length, in bytes, for the first synchronous write/read test.
-const SYNC_TEST_SMALL_LENGTH: u32 = 512;
-/// Transfer length, in bytes, for the second synchronous write/read test.
-const SYNC_TEST_LARGE_LENGTH: u32 = 30 * 1024;
-/// Completion key associated with the device handle on the I/O completion port.
-const COMPLETION_PORT_KEY: usize = 1;
-/// Number of concurrent threads allowed to run for the I/O completion port.
-/// Zero lets the system allow as many concurrent threads as there are
-/// processors.
-const COMPLETION_PORT_CONCURRENT_THREADS: u32 = 0;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    /// Transfer length, in bytes, for the first synchronous write/read test.
+    const SYNC_TEST_SMALL_LENGTH: u32 = 512;
+    /// Transfer length, in bytes, for the second synchronous write/read test.
+    const SYNC_TEST_LARGE_LENGTH: u32 = 30 * 1024;
+
     let argument_vector: Vec<String> = env::args().collect();
     let argument_count = argument_vector.len();
 
@@ -302,6 +297,13 @@ fn async_io(thread_parameter: u32) -> Result<(), Box<dyn Error + Send + Sync>> {
 // function warning
 #[allow(clippy::too_many_lines)]
 fn async_io_work(io_type: u32) -> Result<(), Box<dyn Error>> {
+    /// Completion key associated with the device handle on the I/O completion port.
+    const COMPLETION_PORT_KEY: usize = 1;
+    /// Number of concurrent threads allowed to run for the I/O completion port.
+    /// Zero lets the system allow as many concurrent threads as there are
+    /// processors.
+    const COMPLETION_PORT_CONCURRENT_THREADS: u32 = 0;
+
     let globals = GLOBAL_DATA.read()?;
 
     let h_device: HANDLE;

--- a/general/echo/kmdf/exe/src/main.rs
+++ b/general/echo/kmdf/exe/src/main.rs
@@ -297,7 +297,8 @@ fn async_io(thread_parameter: u32) -> Result<(), Box<dyn Error + Send + Sync>> {
 // function warning
 #[allow(clippy::too_many_lines)]
 fn async_io_work(io_type: u32) -> Result<(), Box<dyn Error>> {
-    /// Completion key associated with the device handle on the I/O completion port.
+    /// Completion key associated with the device handle on the I/O completion
+    /// port.
     const COMPLETION_PORT_KEY: usize = 1;
     /// Number of concurrent threads allowed to run for the I/O completion port.
     /// Zero lets the system allow as many concurrent threads as there are

--- a/general/echo/kmdf/exe/src/main.rs
+++ b/general/echo/kmdf/exe/src/main.rs
@@ -71,15 +71,15 @@ static WRITER_TYPE: u32 = 2;
 static NUM_ASYNCH_IO: usize = 100;
 static BUFFER_SIZE: usize = 40 * 1024;
 /// Transfer length, in bytes, for the first synchronous write/read test.
-static SYNC_TEST_SMALL_LENGTH: u32 = 512;
+const SYNC_TEST_SMALL_LENGTH: u32 = 512;
 /// Transfer length, in bytes, for the second synchronous write/read test.
-static SYNC_TEST_LARGE_LENGTH: u32 = 30 * 1024;
+const SYNC_TEST_LARGE_LENGTH: u32 = 30 * 1024;
 /// Completion key associated with the device handle on the I/O completion port.
-static COMPLETION_PORT_KEY: usize = 1;
+const COMPLETION_PORT_KEY: usize = 1;
 /// Number of concurrent threads allowed to run for the I/O completion port.
 /// Zero lets the system allow as many concurrent threads as there are
 /// processors.
-static COMPLETION_PORT_CONCURRENT_THREADS: u32 = 0;
+const COMPLETION_PORT_CONCURRENT_THREADS: u32 = 0;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let argument_vector: Vec<String> = env::args().collect();

--- a/general/echo/kmdf/exe/src/main.rs
+++ b/general/echo/kmdf/exe/src/main.rs
@@ -70,6 +70,16 @@ static READER_TYPE: u32 = 1;
 static WRITER_TYPE: u32 = 2;
 static NUM_ASYNCH_IO: usize = 100;
 static BUFFER_SIZE: usize = 40 * 1024;
+/// Transfer length, in bytes, for the first synchronous write/read test.
+static SYNC_TEST_SMALL_LENGTH: u32 = 512;
+/// Transfer length, in bytes, for the second synchronous write/read test.
+static SYNC_TEST_LARGE_LENGTH: u32 = 30 * 1024;
+/// Completion key associated with the device handle on the I/O completion port.
+static COMPLETION_PORT_KEY: usize = 1;
+/// Number of concurrent threads allowed to run for the I/O completion port.
+/// Zero lets the system allow as many concurrent threads as there are
+/// processors.
+static COMPLETION_PORT_CONCURRENT_THREADS: u32 = 0;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let argument_vector: Vec<String> = env::args().collect();
@@ -155,9 +165,9 @@ Exit the app anytime by pressing Ctrl-C
 
         h.join().unwrap().unwrap();
     } else {
-        perform_write_read_test(h_device, 512)?;
+        perform_write_read_test(h_device, SYNC_TEST_SMALL_LENGTH)?;
 
-        perform_write_read_test(h_device, 30 * 1024)?;
+        perform_write_read_test(h_device, SYNC_TEST_LARGE_LENGTH)?;
     }
 
     Ok(())
@@ -334,7 +344,12 @@ fn async_io_work(io_type: u32) -> Result<(), Box<dyn Error>> {
     // Call Win32 API FFI CreateIoCompletionPort to get handle for completing async
     // requests
     unsafe {
-        h_completion_port = CreateIoCompletionPort(h_device, std::ptr::null_mut(), 1, 0);
+        h_completion_port = CreateIoCompletionPort(
+            h_device,
+            std::ptr::null_mut(),
+            COMPLETION_PORT_KEY,
+            COMPLETION_PORT_CONCURRENT_THREADS,
+        );
     }
 
     if h_completion_port.is_null() {


### PR DESCRIPTION
## Summary

Decompose magic numbers into `const`'s adding relevant documentation.